### PR TITLE
feat: mostrar color mesa segun estado

### DIFF
--- a/src/app/pages/reservas/reservas.component.html
+++ b/src/app/pages/reservas/reservas.component.html
@@ -41,28 +41,28 @@
     <img src="/mesas/mesas.png" alt="Mapa de mesas" />
 
     <div
-  *ngFor="let mesa of mesas"
-  class="mesa-overlay"
-  [ngClass]="{ 'mesa-disponible': mesa.estado === 'DISPONIBLE' }"
-  [ngStyle]="{
-    top: posicionesMesa[mesa.numeroMesa].top,
-    left: posicionesMesa[mesa.numeroMesa].left,
-    width: posicionesMesa[mesa.numeroMesa].width,
-    height: posicionesMesa[mesa.numeroMesa].height,
-    backgroundColor: mesa.estado === 'DISPONIBLE'
-      ? 'rgba(0,255,0,0.2)'
-      : mesa.estado === 'RESERVADO'
-      ? 'rgba(255,0,0,0.3)'
-      : 'rgba(255,255,0,0.3)'
-  }"
->
+      *ngFor="let mesa of mesas"
+      class="mesa-overlay"
+      [ngClass]="{ 'mesa-disponible': mesa.estado === 'DISPONIBLE' }"
+      [ngStyle]="{
+        top: posicionesMesa[mesa.numeroMesa].top,
+        left: posicionesMesa[mesa.numeroMesa].left,
+        width: posicionesMesa[mesa.numeroMesa].width,
+        height: posicionesMesa[mesa.numeroMesa].height,
+        backgroundColor: mesa.estado === 'DISPONIBLE'
+          ? 'rgba(0,255,0,0.2)'
+          : mesa.estado === 'RESERVADO'
+          ? 'rgba(255,0,0,0.3)'
+          : 'rgba(255,255,0,0.3)'
+      }"
+    >
       <div class="tooltip">
         <div><strong>Mesa {{ mesa.numeroMesa }}</strong></div>
-        <div>Zona: {{ mesa.zoneName }}</div> <!-- ✅ CORREGIDO -->
+        <div>Zona: {{ mesa.zoneName }}</div>
         <div>Capacidad: {{ mesa.capacidad }}</div>
         <div>Estado: {{ mesa.estado }}</div>
 
-        <!-- Si está disponible: permitir ir a /registro-reservas -->
+        <!-- Mostrar botón solo si está disponible -->
         <button
           class="btn-reservar"
           *ngIf="mesa.estado === 'DISPONIBLE'"
@@ -71,6 +71,10 @@
           Empezar reserva
         </button>
 
+        <!-- Mostrar texto si está en estado reservándose -->
+        <span *ngIf="mesa.estado === 'RESERVANDOSE'" class="estado-mesa">
+          Reservándose...
+        </span>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Se implementa la funcionalidad para que el cliente pueda diferenciar visualmente las mesas según su estado mediante colores:
1. Las mesas disponibles se muestran en color verde.
2. Las mesas que están en proceso de reserva (estado "reservándose") se muestran en color amarillo.
3. Las mesas reservadas u ocupadas se muestran en color rojo.

Además, se asegura que no se puedan hacer dos reservas simultáneas sobre la misma mesa para la misma fecha y hora, mediante la simulación del estado "reservándose" que bloquea temporalmente la mesa.
Estos cambios se reflejan en la vista general de mesas y ayudan a que el cliente identifique fácilmente el estado de cada mesa en tiempo real.
![image](https://github.com/user-attachments/assets/56f0d52e-7dda-4b73-8def-ef03dedaa219)
![image](https://github.com/user-attachments/assets/fbfcf652-7f4f-497f-b579-9bdb1b24ee8d)

