### PR TITLE
feat: modificar asistencia

### DIFF
--- a/src/app/core/services/reservation.service.ts
+++ b/src/app/core/services/reservation.service.ts
@@ -58,4 +58,10 @@ export class ReservationService {
   getAllReservationsForAdmin(): Observable<any[]> {
   return this.http.get<any[]>(`${this.baseUrl}/admin/reservations`);
 }
+
+// Confirmar asistencia de una reserva
+confirmAttendance(id: number): Observable<Reservation> {
+  return this.http.put<Reservation>(`${this.baseUrl}/${id}/confirm-attendance`, {});
+}
+
 }

--- a/src/app/pages/lista-reservas/lista-reservas.component.css
+++ b/src/app/pages/lista-reservas/lista-reservas.component.css
@@ -84,6 +84,45 @@
     text-align: center;
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
 }
+.estado {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 5px 10px;
+  border-radius: 8px;
+  font-weight: bold;
+}
+
+/* Estilo para estado asistió */
+.estado.asistio {
+  background-color: #2ecc71;
+  color: white;
+}
+
+/* Texto cuando está en espera */
+.en-espera-text {
+  color: #e67e22;
+  font-weight: bold;
+}
+
+/* Estilo para el botón Confirmar */
+.confirmar-btn {
+  background-color: #3498db;
+  color: white;
+  border: none;
+  padding: 6px 12px;
+  border-radius: 5px;
+  font-weight: bold;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  transition: background-color 0.3s ease;
+}
+
+.confirmar-btn:hover {
+  background-color: #2980b9;
+}
+
 
 .asistio {
     background-color: #2ce83d;

--- a/src/app/pages/lista-reservas/lista-reservas.component.html
+++ b/src/app/pages/lista-reservas/lista-reservas.component.html
@@ -38,7 +38,16 @@
         </div>
         <div class="hora">Hora: {{ r.horaInicio.slice(0, 5) }}</div>
       </div>
-      <div class="estado asistio">ASISTIÓ</div> <!-- temporal -->
+
+      <div class="estado" [ngClass]="{'asistio': r.stateReservationClient === 'ASISTIO' || esPasada(r.fechaReservada)}">
+        <ng-container *ngIf="r.stateReservationClient === 'ASISTIO' || esPasada(r.fechaReservada); else enEsperaBlock">
+          ASISTIÓ
+        </ng-container>
+        <ng-template #enEsperaBlock>
+          <span class="en-espera-text">EN ESPERA</span>
+          <button class="confirmar-btn" (click)="confirmAttendance(r.id)">Confirmar</button>
+        </ng-template>
+      </div>
     </div>
   </div>
 </main>

--- a/src/app/pages/lista-reservas/lista-reservas.component.ts
+++ b/src/app/pages/lista-reservas/lista-reservas.component.ts
@@ -16,9 +16,35 @@ export class ListaReservasComponent implements OnInit {
   constructor(private reservationService: ReservationService) {}
 
   ngOnInit(): void {
+    this.loadReservations();
+  }
+
+  loadReservations(): void {
     this.reservationService.getReservationList().subscribe({
       next: (data) => this.reservas = data,
       error: (err) => console.error('❌ Error al cargar reservas:', err)
     });
+  }
+
+  confirmAttendance(id: number): void {
+    this.reservationService.confirmAttendance(id).subscribe({
+      next: () => {
+        const reserva = this.reservas.find(r => r.id === id);
+        if (reserva) {
+          reserva.stateReservationClient = 'ASISTIO';
+          alert('✅ Asistencia confirmada');
+        }
+      },
+      error: (err) => {
+        console.error('❌ Error al confirmar asistencia:', err);
+        alert('❌ No se pudo confirmar la asistencia');
+      }
+    });
+  }
+
+  esPasada(fecha: string): boolean {
+    const hoy = new Date();
+    const fechaReserva = new Date(fecha);
+    return fechaReserva < hoy;
   }
 }

--- a/src/app/shared/models/reservation-list.model.ts
+++ b/src/app/shared/models/reservation-list.model.ts
@@ -6,4 +6,5 @@ export interface ReservationList {
   zone: string;
   fechaReservada: string;   // yyyy-MM-dd
   horaInicio: string;       // HH:mm:ss
+  stateReservationClient: 'EN_ESPERA' | 'ASISTIO' | 'NO_ASISTIO';
 }

--- a/src/app/shared/models/reservation.model.ts
+++ b/src/app/shared/models/reservation.model.ts
@@ -9,5 +9,5 @@ export interface Reservation {
   telefonoCliente: string;
   dniCliente: string;
   stateReservation?: 'PENDIENTE' | 'RESERVADA'; // opcional, o string si prefieres
-  stateReservationClient?: 'EN_ESPERA' | 'ASISTIO' | 'NO_ASISTIO'; // ⚠️ faltaba
+  stateReservationClient?: 'EN_ESPERA' | 'ASISTIO' | 'NO_ASISTIO'; 
 }


### PR DESCRIPTION
Se actualizó la interfaz del administrador para mejorar el manejo visual del estado de asistencia en las reservas.

- Se agregó un botón de “Confirmar” junto a las reservas con estado EN_ESPERA.
- Al confirmar, el estado se actualiza dinámicamente a ASISTIÓ y se muestra una alerta visual de confirmación.
- Las reservas cuya fecha ya ha pasado se muestran automáticamente con el estado ASISTIÓ, ocultando el botón de confirmación.
![image](https://github.com/user-attachments/assets/ce662d31-5e26-4d4c-8eb0-1a6113ba1eca)
![image](https://github.com/user-attachments/assets/cd41ad9f-2128-48ac-9d2f-0f993592108c)
![image](https://github.com/user-attachments/assets/b5fccd38-a034-4017-a315-319a4ce2ca7e)